### PR TITLE
!환율 허용

### DIFF
--- a/ManalithBot/src/main/java/org/manalith/ircbot/plugin/cer2/CERPlugin.java
+++ b/ManalithBot/src/main/java/org/manalith/ircbot/plugin/cer2/CERPlugin.java
@@ -44,7 +44,7 @@ public class CERPlugin extends AbstractBotPlugin {
 	 * @see org.manalith.ircbot.plugin.IBotPlugin#getNamespace()
 	 */
 	public String getNamespace() {
-		return "curex";
+		return "curex|환율";
 	}
 
 	/*
@@ -83,76 +83,71 @@ public class CERPlugin extends AbstractBotPlugin {
 		String channel = event.getChannel();
 
 		String[] command = msg.split("\\s");
-		if (command[0].length() < 6)
-		{
-			// do not recognize as cmd and just return
-			return;
-		}
-		else if (command[0].substring(0, 6).equals("!curex")) {
-			String[] subcmd = command[0].split("\\:");
-			if (!subcmd[0].equals("!curex"))
-				return;
-			else {
-				if (subcmd.length == 1) {
-					String mergedcmd = "";
-					for (int i = 1; i < command.length; i++) {
-						mergedcmd += command[i];
-						if (i != command.length - 1)
-							mergedcmd += " ";
-					}
+		if (!command[0].equals("!curex") &&
+		    !command[0].equals("!환율") &&
+		    !command[0].startsWith("!curex:") &&
+		    !command[0].startsWith("!환율:"))
+		    return;
 
-					try {
-						CERRunner runner = new CERRunner(
-								event.getSender(), this.getResourcePath(),
-								mergedcmd);
+		String[] subcmd = command[0].split("\\:");
+		if (subcmd.length == 1) {
+			String mergedcmd = "";
+			for (int i = 1; i < command.length; i++) {
+				mergedcmd += command[i];
+				if (i != command.length - 1)
+					mergedcmd += " ";
+			}
 
-						String result = runner.run();
-						if (result.equals("Help!")) {
-							bot.sendLoggedMessage(channel,
-									CERInfoProvider.getIRCHelpMessagePart1());
-							bot.sendLoggedMessage(channel,
-									CERInfoProvider.getIRCHelpMessagePart2());
-							bot.sendLoggedMessage(channel,
-									CERInfoProvider.getIRCHelpMessagePart3());
-							bot.sendLoggedMessage(channel,
-									CERInfoProvider.getIRCHelpMessagePart4());
-						} else {
-							bot.sendLoggedMessage(channel, result);
-						}
-					} catch (Exception e) {
-						bot.sendLoggedMessage(channel, e.getMessage());
-					}
+			try {
+				CERRunner runner = new CERRunner(
+						event.getSender(), this.getResourcePath(),
+						mergedcmd);
+
+				String result = runner.run();
+				if (result.equals("Help!")) {
+					bot.sendLoggedMessage(channel,
+							CERInfoProvider.getIRCHelpMessagePart1());
+					bot.sendLoggedMessage(channel,
+							CERInfoProvider.getIRCHelpMessagePart2());
+					bot.sendLoggedMessage(channel,
+							CERInfoProvider.getIRCHelpMessagePart3());
+					bot.sendLoggedMessage(channel,
+							CERInfoProvider.getIRCHelpMessagePart4());
+				} else {
+					bot.sendLoggedMessage(channel, result);
 				}
-				else if (subcmd.length > 2)
-				{
-					bot.sendLoggedMessage(channel, "옵션이 너무 많습니다");
-				}
-				else {
-					// remerge strings separated by space.
-					String userNick = event.getSender();
-
-					String arg = "";
-					for (int i = 1; i < command.length; i++) {
-						if (command[i].equals(" "))
-							continue;
-						arg += command[i];
-					}
-
-					CERCustomSettingManager csMan = new CERCustomSettingManager(
-							this.getResourcePath(), channel, userNick, arg);
-
-					if (subcmd[1].equals("sub"))
-						bot.sendLoggedMessage(channel, csMan.addUserSetting());
-					else if (subcmd[1].equals("unsub"))
-						
-						bot.sendLoggedMessage(channel,
-								csMan.removeUserSetting());
-					else
-						bot.sendLoggedMessage(channel, "그런 옵션은 없습니다.");
-
-				}
-				event.setExecuted(true);
+			} catch (Exception e) {
+				bot.sendLoggedMessage(channel, e.getMessage());
 			}
 		}
+		else if (subcmd.length > 2)
+		{
+			bot.sendLoggedMessage(channel, "옵션이 너무 많습니다");
+		}
+		else {
+			// remerge strings separated by space.
+			String userNick = event.getSender();
+
+			String arg = "";
+			for (int i = 1; i < command.length; i++) {
+				if (command[i].equals(" "))
+					continue;
+				arg += command[i];
+			}
+
+			CERCustomSettingManager csMan = new CERCustomSettingManager(
+					this.getResourcePath(), channel, userNick, arg);
+
+			if (subcmd[1].equals("sub"))
+				bot.sendLoggedMessage(channel, csMan.addUserSetting());
+			else if (subcmd[1].equals("unsub"))
+				
+				bot.sendLoggedMessage(channel,
+						csMan.removeUserSetting());
+			else
+				bot.sendLoggedMessage(channel, "그런 옵션은 없습니다.");
+
+		}
+		event.setExecuted(true);
 	}
 }


### PR DESCRIPTION
환율 명령으로 !curex 대신에 !환율 명령을 사용할 수 있도록 허용. curex
같은 신조어 약자는 기억하기 어렵다.

추가로 봇 명령어가 올바른지 확인하는 코드 단순화.
