### PR TITLE
URI title 플러그인에서 setExecuted() 제외

### DIFF
--- a/ManalithBot/src/main/java/org/manalith/ircbot/plugin/urititle/UriTitlePlugin.java
+++ b/ManalithBot/src/main/java/org/manalith/ircbot/plugin/urititle/UriTitlePlugin.java
@@ -75,6 +75,8 @@ public class UriTitlePlugin extends AbstractBotPlugin {
 		if (title != null) {
 			bot.sendLoggedMessage(channel, "[Link Title] " + title);
 		}
-		event.setExecuted(true);
+
+		// This plugin runs implicitly; NO need to call
+		// event.setExecuted(true)
 	}
 }


### PR DESCRIPTION
이 것 때문에 명령어에 URL이 포함되었을 경우 다른 플러그인이 실행하지
못할 수 있다.

이 명령어는 어차피 배타적으로 실행해야 할 명령어가 아님.

(예) 뒷북요정: 배워 구글 http://google.com
