### PR TITLE
URIInfo: URL의 non-ASCII 문자를 인코딩

### DIFF
--- a/ManalithBot/src/main/java/org/manalith/ircbot/util/MessageUtils.java
+++ b/ManalithBot/src/main/java/org/manalith/ircbot/util/MessageUtils.java
@@ -1,5 +1,7 @@
 package org.manalith.ircbot.util;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,6 +25,10 @@ public class MessageUtils {
 		if (!matcher.matches())
 			return null;
 
-		return matcher.group(1);
+		try {
+			return new URI(matcher.group(1)).toASCIIString();
+		} catch (URISyntaxException e) {
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
URL에 들어간 non-ASCII 문자를 UTF-8 문자열로 가정하고 인코딩. 일부 웹
서버는 한글을 그대로 입력한 경우 오류가 발생하고, 이스케이프해야
동작하는 경우가 있다.

예: http://mirror.enha.kr/wiki/리그베다%20위키
