### PR TITLE
keySeqConvPlugin: 명령어/인자 파싱 바로잡음

### DIFF
--- a/ManalithBot/src/main/java/org/manalith/ircbot/plugin/keyseqconv/KeySeqConvPlugin.java
+++ b/ManalithBot/src/main/java/org/manalith/ircbot/plugin/keyseqconv/KeySeqConvPlugin.java
@@ -71,10 +71,16 @@ public class KeySeqConvPlugin extends SimplePlugin {
 		stengine.setEnableParsingExceptionSyntax(enableParsingExceptionSyntax);
 		snengine.setEnableParsingExceptionSyntax(enableParsingExceptionSyntax);
 
-		String cmd = msg.split("\\s")[0];
-		String srcmsg = msg.substring(msg.indexOf(' ') + 1, msg.length());
-		String dstmsg = "";
+		String [] args = msg.split("\\s", 2);
+		if (args.length != 2) {
+			event.respond(getHelp());
+			return;
+		}
 
+		String cmd = args[0];
+		String srcmsg = args[1];
+		String dstmsg = "";
+                
 		try {
 			switch (cmd) {
 			case "!c2":


### PR DESCRIPTION
명령어와 인자를 구분할 때 "msg.indexOf(' ') + 1"과 같이 쓰는 바람에
인자 없이 사용할 때 다음과 같이 명령어와 인자가 동일해 진다.

```
   <changwoo> !c2
   <뒷북요정> <changwoo> !ㅊ2
```

인자가 없을 때 도움말 표시.
